### PR TITLE
Fix for gradient not redrawing when view bounds change

### DIFF
--- a/EZYGradientView/EZYGradientView.m
+++ b/EZYGradientView/EZYGradientView.m
@@ -82,6 +82,13 @@ struct EZYLocations EZYLocationsMake(CGFloat firstColor, CGFloat secondColor)
   return self;
 }
 
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+
+  [self setNeedsDisplay];
+}
+
 #pragma mark - Draw Rect with steps
 
 - (void)drawRect:(CGRect)rect

--- a/EZYGradientView/EZYGradientView.m
+++ b/EZYGradientView/EZYGradientView.m
@@ -89,9 +89,9 @@ struct EZYLocations EZYLocationsMake(CGFloat firstColor, CGFloat secondColor)
   if (_gradientLayer == nil)
   {
     _gradientLayer = [CAGradientLayer layer];
-    _gradientLayer.frame = self.bounds;
     [self.layer insertSublayer:_gradientLayer atIndex:0];
   }
+  _gradientLayer.frame = self.bounds;
   [self updateColors];
   [self updatePoints];
   [self updateLocations];


### PR DESCRIPTION
On changing size of view, gradient would not update. Now drawRect takes new bounds into account and setNeedsDisplay is called in layoutSubviews so view is redrawn automatically.